### PR TITLE
add buildtest project for good first issues

### DIFF
--- a/.github/repos.txt
+++ b/.github/repos.txt
@@ -245,3 +245,4 @@ https://github.com/PetroFit/petrofit
 https://github.com/glotzerlab/coxeter
 https://github.com/dicompyler/dicompyler-core
 https://github.com/cogent3/cogent3
+https://github.com/buildtesters/buildtest


### PR DESCRIPTION
i am the lead developer of buildtest so i wanted to add this so it shows up in the first issues. I came across the hpc.social talk at EUM. Great talk btw @vsoch. 

Please let me know if i did correctly.