### PR TITLE
Fix: Improve visibility of dropdown menu options in dark mode

### DIFF
--- a/docs/assets/css/jobs.css
+++ b/docs/assets/css/jobs.css
@@ -418,8 +418,8 @@ pre{font-size: 14px; max-width: 90vw; overflow: auto;}
 }
 
 .dataTables_wrapper .dataTables_length select {
-  color: var(--font-color);
-  border: 1px solid var(--font-color);
-  background-color: transparent;
+  color: var(--primary-font-color);
+  border: 1px solid var(--border-color);
+  background-color: var(--bg-color);
   padding: 4px;
 }


### PR DESCRIPTION
### 📌 What does this PR do?

This PR fixes the visibility issue of dropdown filters in dark mode (e.g., Show entries, Repository, Tags).

---

### 🐞 Before (Issue Screenshot)
<img width="1717" height="865" alt="Screenshot 2025-07-13 132719" src="https://github.com/user-attachments/assets/5e8f5345-c8e0-4482-9717-ce617589a504" />


---

### ✅ After (Fixed UI)
<img width="1634" height="871" alt="Screenshot 2025-07-13 141612" src="https://github.com/user-attachments/assets/088f0088-e4df-4cf7-bdbd-b2c49f5040f0" />


---

### 🔧 Changes Made

- Updated styles in `jobs.css` to improve contrast and visibility
- Ensured consistency across dark and light modes

---

### 🔗 Related Issue

Fixes #8
